### PR TITLE
Enable issuing a proof point from an identity linked to an internet domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "proof-points",
+  "name": "@provenance/proof-points",
   "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -24,10 +24,30 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@stablelib/utf8": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-0.10.1.tgz",
+      "integrity": "sha512-+uM1YZ4MhBC82vt99prF7DXNGqhYmJ9cQ3p5qNowMNkkzn9OWEkqBvguBW3ChAt7JvqZ3SD5HJOfc6YgnfMTHw=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -81,9 +101,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -985,9 +1005,9 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -1173,6 +1193,34 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "did-jwt": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/did-jwt/-/did-jwt-4.1.0.tgz",
+      "integrity": "sha512-aW8QYgRaPAiFeVjdwH5H4nLJrfo9PmOi//gVUOXQRU0jzhZvL3nnpxVEPfrTpIpI+GQ/tmET8/NoyYShmPuyKA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@stablelib/utf8": "^0.10.1",
+        "buffer": "^5.2.1",
+        "did-resolver": "^1.0.0",
+        "elliptic": "^6.4.0",
+        "js-sha256": "^0.9.0",
+        "js-sha3": "^0.8.0",
+        "tweetnacl": "^1.0.1",
+        "uport-base64url": "3.0.2-alpha.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "did-resolver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
+      "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1269,7 +1317,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -1424,12 +1471,20 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         },
         "ms": {
@@ -2492,6 +2547,48 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
     },
+    "http-call": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/http-call/-/http-call-5.3.0.tgz",
+      "integrity": "sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==",
+      "requires": {
+        "content-type": "^1.0.4",
+        "debug": "^4.1.1",
+        "is-retry-allowed": "^1.1.0",
+        "is-stream": "^2.0.0",
+        "parse-json": "^4.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -2713,8 +2810,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -2936,6 +3032,11 @@
         "is-object": "^1.0.1"
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -2966,6 +3067,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3262,7 +3368,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minipass": {
       "version": "2.9.0",
@@ -4969,11 +5076,18 @@
       },
       "dependencies": {
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            }
           }
         }
       }
@@ -5243,9 +5357,9 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.1.tgz",
+      "integrity": "sha512-sgDYfSDPMsA4Hr2/w7vOlrJBlwzmyakk1+hW8ObLvxSp0LA36LcL2XItGvOT3OSblohSdevMuT8FQjLsqyy4sA==",
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -5316,6 +5430,14 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
+      }
+    },
+    "uport-base64url": {
+      "version": "3.0.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/uport-base64url/-/uport-base64url-3.0.2-alpha.0.tgz",
+      "integrity": "sha512-pRu0xm1K39IUzuMQEmFWdqP+H8jOzblwTXf0r9wFBCa6ZLLQsNuDeUwB2Ld+9zlBSvQQv+XEzG7cQukSCueZqw==",
+      "requires": {
+        "buffer": "^5.2.1"
       }
     },
     "uri-js": {
@@ -5794,12 +5916,20 @@
       },
       "dependencies": {
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "dev": true
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
   "homepage": "https://github.com/ProjectProvenance/ProofPoints#readme",
   "dependencies": {
     "canonicalize": "^1.0.1",
+    "did-jwt": "^4.1.0",
+    "http-call": "^5.3.0",
+    "ipfs-mini": "1.1.5",
     "local-iso-dt": "^1.2.2",
-    "web3": "^1.2.5",
-    "ipfs-mini": "1.1.5"
+    "web3": "^1.2.5"
   },
   "devDependencies": {
     "blueimp-md5": "2.12.0",

--- a/src/controllers/VerySimpleEthrDidResolver.js
+++ b/src/controllers/VerySimpleEthrDidResolver.js
@@ -1,0 +1,27 @@
+
+class VerySimpleEthrDidResolver {
+  constructor() {
+    this.resolve = async function(did) {
+      return {
+        '@context': 'https://w3id.org/did/v1',
+        id: did,
+        publicKey: [
+          {
+            id: `${did}#owner`,
+            type: 'Secp256k1VerificationKey2018',
+            owner: did,
+            ethereumAddress: did.substr(9).toLowerCase()
+          }
+        ],
+        authentication: [
+          {
+            type: 'Secp256k1SignatureAuthentication2018',
+            publicKey: `${did}#owner`
+          }
+        ]
+      };
+    }
+  }
+}
+
+module.exports = VerySimpleEthrDidResolver;

--- a/test/proofPoints.js
+++ b/test/proofPoints.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const didJWT = require('did-jwt');
 const Provenance = require('../src');
 const FakeStorageProvider = require('./fixtures/FakeStorageProvider');
 
@@ -23,6 +24,55 @@ async function deployProofPointRegistry(web3, storageProvider, admin) {
     .send({ from: admin, gas: 1000000 });
 
   return eternalStorage.options.address;
+}
+
+async function buildWellKnownDidResource(acc, domain) {
+  const payload = {
+    sub: 'did:ethr:' + acc.address,
+    iss: 'did:ethr:' + acc.address,
+    vc: {
+      '@context': [
+        'https://www.w3.org/2018/credentials/v1',
+        'https://identity.foundation/.well-known/contexts/did-configuration-v0.0.jsonld'
+      ],
+      issuer: 'did:ethr:' + acc.address,
+      type: [
+        'VerifiableCredential',
+        'DomainLinkageCredential'
+      ],
+      credentialSubject: {
+        id: 'did:ethr:' + acc.address,
+        domain: domain
+      }
+    }
+  }
+
+  const signer = didJWT.SimpleSigner(acc.privateKey.substr(2));
+
+  const jwt = await didJWT.createJWT(
+    payload,
+    {
+      alg: 'ES256K-R',
+      issuer: 'did:ethr:' + acc.address,
+      signer
+    }
+  );
+
+  const resource = {
+    '@context': 'https://identity.foundation/.well-known/contexts/did-configuration-v0.0.jsonld',
+    entries: [jwt]
+  }
+
+  return resource
+}
+
+async function createAndFundAccount() {
+  const acc = await web3.eth.accounts.create();
+  web3.eth.accounts.wallet.add(acc);
+  await web3.eth.sendTransaction(
+    { from: (await web3.eth.getAccounts())[0], to: acc.address, value: 400000000000000 }
+  );
+  return acc;
 }
 
 contract('ProofPoints', () => {
@@ -146,5 +196,178 @@ contract('ProofPoints', () => {
 
     const isValidProofPoint = await p2.proofPoint.validate(results.proofPointObject);
     expect(isValidProofPoint).to.be.false;
+  });
+
+  it('non domain issuer is treated as ethereum address', async() => {
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      throw new Error('well known resource should not be fetched for ethereum address issuer');
+    }
+
+    const results = await p.proofPoint.issue(
+      type,
+      admin,
+      content
+    );
+
+    const isValidProofPoint = await p.proofPoint.validate(results.proofPointObject);
+    expect(isValidProofPoint).to.eq(true);
+  });
+
+  it('domain issuer happy path', async() => {
+    // the resource at the well know path for the given domain is a valid DID config linking to acc
+    const acc = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function(domain) {
+      return buildWellKnownDidResource(acc, domain);
+    }
+
+    const results = await p.proofPoint.issue(
+      type,
+      'example.com',
+      content
+    );
+
+    expect(results.proofPointObject.issuer).to.eq('example.com');
+    expect(results.proofPointObject.proof.verificationMethod).to.eq('example.com');
+
+    const isValidProofPoint = await p.proofPoint.validate(results.proofPointObject);
+    expect(isValidProofPoint).to.eq(true);
+  });
+
+  it('if issuer is domain and well known resource is not valid DID configuration then issue fails', async() => {
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      return '{}';
+    }
+
+    try {
+      await p.proofPoint.issue(
+        type,
+        'example.com',
+        content
+      );
+    } catch (e) {
+      // OK
+      return;
+    }
+
+    throw new Error('issue should have failed');
+  });
+
+  it('if issuer is domain and well known resource cannot be fetched then issue fails', async() => {
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      throw new Error('bang!')
+    }
+
+    try {
+      await p.proofPoint.issue(
+        type,
+        'example.com',
+        content
+      );
+    } catch (e) {
+      // OK
+      return;
+    }
+
+    throw new Error('issue should have failed');
+  });
+
+  it('if issuer is domain and well known resource is not valid DID configuration then validate fails', async() => {
+    const acc = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function(domain) {
+      return buildWellKnownDidResource(acc, domain);
+    }
+
+    const results = await p.proofPoint.issue(
+      type,
+      'example.com',
+      content
+    );
+
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      return '{}'
+    }
+
+    const isValidProofPoint = await p.proofPoint.validate(results.proofPointObject);
+    expect(isValidProofPoint).to.eq(false);
+  });
+
+  it('if issuer is domain and well known resource cannot be fetched then validate fails', async() => {
+    const acc = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function(domain) {
+      return buildWellKnownDidResource(acc, domain);
+    }
+
+    const results = await p.proofPoint.issue(
+      type,
+      'example.com',
+      content
+    );
+
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      throw new Error('bang!')
+    }
+
+    const isValidProofPoint = await p.proofPoint.validate(results.proofPointObject);
+    expect(isValidProofPoint).to.eq(false);
+  });
+
+  it('if issuer is domain and well known resource is valid but points to a different account then validate fails', async() => {
+    const acc1 = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function(domain) {
+      return buildWellKnownDidResource(acc1, domain);
+    }
+
+    const results = await p.proofPoint.issue(
+      type,
+      'example.com',
+      content
+    );
+
+    const acc2 = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function(domain) {
+      return buildWellKnownDidResource(acc2, domain);
+    }
+
+    const isValidProofPoint = await p.proofPoint.validate(results.proofPointObject);
+    expect(isValidProofPoint).to.eq(false);
+  });
+
+  it('if issuer is domain and well known resource is otherwise valid but names a different domain then issue fails', async() => {
+    const acc = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      return buildWellKnownDidResource(acc, 'another-domain.com');
+    }
+
+    try {
+      await p.proofPoint.issue(
+        type,
+        'example.com',
+        content
+      );
+    } catch (e) {
+      return;
+    }
+
+    throw new Error('issue should have failed');
+  });
+
+  it('if issuer is domain and well known resource is otherwise valid but names a different domain then validate fails', async() => {
+    const acc = await createAndFundAccount();
+    p.proofPoint.fetchWellKnownDidResource = function(domain) {
+      return buildWellKnownDidResource(acc, domain);
+    }
+
+    const results = await p.proofPoint.issue(
+      type,
+      'example.com',
+      content
+    );
+
+    p.proofPoint.fetchWellKnownDidResource = function() {
+      return buildWellKnownDidResource(acc, 'another-domain.com');
+    }
+
+    const isValidProofPoint = await p.proofPoint.validate(results.proofPointObject);
+    expect(isValidProofPoint).to.eq(false);
   });
 });


### PR DESCRIPTION
This is a backwards compatible change to `issue`, `commit` and `verify` functions that allows to use an internet domain name as a valid `issuer`. This is possible using [Well Known DID Configuration](https://identity.foundation/.well-known/resources/did-configuration/#domain-linkage-credential) and the `ethr` DID method and requires the issuer to host a Well Known DID Configuration resource at a well known location under their domain. When used, the internet domain name  will replace the ethereum address in the `issuer` field of the proof point data, while the underlying associated Ethereum address will still be used for  issuance and validation.