### PR TITLE
enable user to provde their own Signer when writing to the reigstry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# NEXT
+
+## New Features
+
+- When writing to the registry you can optionally provide your own signer, which can be useful when using a Provider that cannot provide a Signer.
+
+## Bug Fixes
+
+None
+
+## Breaking Changes
+
+None
+
 # 6.1.0
 
 ## New Features

--- a/test/ProofPointRegistry.test.ts
+++ b/test/ProofPointRegistry.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { Wallet } from "ethers";
+import { ethers, Wallet } from "ethers";
 import {
   ProofPointRegistryRoot,
   ProofPointStatus,
@@ -521,5 +521,54 @@ describe("ProofPointRegistry", () => {
 
     // The Proof Point Id should not be duplicated in getAll
     expect(allIds.length).to.eq(1);
+  });
+
+  it("Should be able to issue with a provided signer", async () => {
+    const signer = provider.getWallets()[1];
+    const results = await subject.issue(
+      type,
+      await signer.getAddress(),
+      content,
+      null,
+      null,
+      signer
+    );
+
+    expect(results.proofPointObject.issuer).to.eq(await signer.getAddress());
+    const validity = await subject.validate(results.proofPointObject);
+    expect(validity.isValid).to.be.true;
+    expect(validity.statusCode).to.eq(ProofPointStatus.Valid);
+  });
+
+  it("Should be able to commit with a provided signer", async () => {
+    const signer = provider.getWallets()[1];
+    const results = await subject.commit(
+      type,
+      await signer.getAddress(),
+      content,
+      null,
+      null,
+      signer
+    );
+
+    expect(results.proofPointObject.issuer).to.eq(await signer.getAddress());
+    const validity = await subject.validate(results.proofPointObject);
+    expect(validity.isValid).to.be.true;
+    expect(validity.statusCode).to.eq(ProofPointStatus.Valid);
+  });
+
+  it("Should be able to revoke with a provided signer", async () => {
+    const signer = provider.getWallets()[1];
+    const results = await subject.issue(
+      type,
+      await signer.getAddress(),
+      content
+    );
+
+    await subject.revoke(results.proofPointObject, signer);
+
+    const validity = await subject.validate(results.proofPointObject);
+    expect(validity.isValid).to.be.false;
+    expect(validity.statusCode).to.eq(ProofPointStatus.NotFound);
   });
 });


### PR DESCRIPTION
This enables the library to be used to write to the registry when metamask is not present, but when instead the private key of the writing account is known, this enables automating registry writes without requiring a user to click a lot of metamask sign requests.