### PR TITLE
Add support for HTTP basic authentication when using IPFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# UNRELEASED
+
+## New Features
+
+- Added support for basic authentication when using IPFS.
+
+## Bug Fixes
+
+None
+
+## Breaking Changes
+
+None
+
 # 7.0.0
 
 ## New Features

--- a/src/ipfs/ipfsStorageProvider.ts
+++ b/src/ipfs/ipfsStorageProvider.ts
@@ -17,12 +17,13 @@ export class IpfsStorageProvider {
     }/api/v0/add?pin=true&hash=sha2-256`;
 
     const formDataBoundary = "2758264728364323843263";
+
     const response = await fetch(url, {
       method: "POST",
       mode: "cors",
-      headers: {
-        "Content-Type": `multipart/form-data; boundary=${formDataBoundary}`,
-      },
+      headers: this.addAuthHeader({
+        "Content-Type": `multipart/form-data; boundary=${formDataBoundary}`
+      }),
       body: `--${formDataBoundary}\nContent-Disposition: form-data; name="path"\n\n${msg}\n--${formDataBoundary}--`,
     });
 
@@ -36,10 +37,24 @@ export class IpfsStorageProvider {
       this.settings.port
     }/api/v0/cat?arg=${digest}`;
 
-    const response = await fetch(url, { method: "POST" });
+    const response = await fetch(url, {
+      method: "POST",
+      headers: this.addAuthHeader({}),
+    });
 
     const data = await response.text();
 
     return { data };
+  }
+
+  addAuthHeader(headers: any): any {
+    if (this.settings.basicAuthenticationToken) {
+      const encodedAuthToken = Buffer.from(
+        this.settings.basicAuthenticationToken
+      ).toString("base64");
+
+      headers.Authorization = `Basic ${encodedAuthToken}`;
+    }
+    return headers;
   }
 }

--- a/src/ipfs/ipfsStorageProviderSettings.ts
+++ b/src/ipfs/ipfsStorageProviderSettings.ts
@@ -2,4 +2,5 @@ export interface IpfsStorageProviderSettings {
   host: string;
   port: number;
   protocol?: string;
+  basicAuthenticationToken?: string;
 }


### PR DESCRIPTION
This will enable using Infura for IPFS hosting.

Calls to the Infura IPFS API require HTTP basic authentication using an API key from Infura. This PR adds support for HTTP basic authentication when reading or writing to/from IPFS. If an authentication key is provided then HTTP basic authentication will be used, otherwise no authentication will be used.